### PR TITLE
#23 [FEAT] 회원가입과 로그인 관련 Entity 기능 수정 및 추가 완료

### DIFF
--- a/src/main/java/com/example/globalStudents/domain/user/entity/CountryEntity.java
+++ b/src/main/java/com/example/globalStudents/domain/user/entity/CountryEntity.java
@@ -23,4 +23,7 @@ public class CountryEntity {
     @OneToMany(mappedBy = "nationality", cascade = CascadeType.ALL)
     private List<UserEntity> CountryUserList = new ArrayList<>();
 
+    @OneToMany(mappedBy = "hostCountry", cascade = CascadeType.ALL)
+    private List<UserEntity> HostCountryUserList = new ArrayList<>();
+
 }

--- a/src/main/java/com/example/globalStudents/domain/user/entity/LanguageEntity.java
+++ b/src/main/java/com/example/globalStudents/domain/user/entity/LanguageEntity.java
@@ -19,4 +19,7 @@ public class LanguageEntity {
     private Long id;
     private String name;
 
+    @OneToMany(mappedBy = "language", cascade = CascadeType.ALL)
+    private List<UserEntity> LanguageUserList = new ArrayList<>();
+
 }

--- a/src/main/java/com/example/globalStudents/domain/user/entity/RegionEntity.java
+++ b/src/main/java/com/example/globalStudents/domain/user/entity/RegionEntity.java
@@ -21,6 +21,6 @@ public class RegionEntity {
     private String name;
 
     @OneToMany(mappedBy = "region", cascade = CascadeType.ALL)
-    private List<UserEntity> RegionUserList = new ArrayList<>();
+    private List<UniversityEntity> RegionUniversityList = new ArrayList<>();
 
 }

--- a/src/main/java/com/example/globalStudents/domain/user/entity/TermsEntity.java
+++ b/src/main/java/com/example/globalStudents/domain/user/entity/TermsEntity.java
@@ -20,8 +20,6 @@ public class TermsEntity {
 
     private String name;
 
-    private String body;
-
     @Column(columnDefinition = "TINYINT(1)")
     private Boolean required;
 

--- a/src/main/java/com/example/globalStudents/domain/user/entity/UniversityEntity.java
+++ b/src/main/java/com/example/globalStudents/domain/user/entity/UniversityEntity.java
@@ -26,4 +26,8 @@ public class UniversityEntity {
 
     @OneToMany(mappedBy = "homeUniversity", cascade = CascadeType.ALL)
     private List<UserEntity> HomeUserList = new ArrayList<>();
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="region_id")
+    private RegionEntity region;
 }

--- a/src/main/java/com/example/globalStudents/domain/user/entity/UserAgreeEntity.java
+++ b/src/main/java/com/example/globalStudents/domain/user/entity/UserAgreeEntity.java
@@ -3,6 +3,8 @@ package com.example.globalStudents.domain.user.entity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
@@ -12,12 +14,23 @@ import lombok.*;
 public class UserAgreeEntity {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="user_id")
     private UserEntity user;
 
-    @Id
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="terms_id")
     private TermsEntity terms;
+
+    @Column(columnDefinition = "TINYINT(1)")
+    private Boolean agree;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+
 }

--- a/src/main/java/com/example/globalStudents/domain/user/entity/UserEntity.java
+++ b/src/main/java/com/example/globalStudents/domain/user/entity/UserEntity.java
@@ -1,5 +1,6 @@
 package com.example.globalStudents.domain.user.entity;
 
+import com.example.globalStudents.domain.board.entity.UserPostReactionEntity;
 import com.example.globalStudents.domain.myPage.entity.UserImageEntity;
 import com.example.globalStudents.domain.user.enums.UserRole;
 import com.example.globalStudents.domain.user.enums.UserStatus;
@@ -22,7 +23,7 @@ public class UserEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private Long uid;
+    private String uid;
 
     private String userId;
 
@@ -34,22 +35,23 @@ public class UserEntity {
 
     private LocalDateTime birth;
 
-    private String pageAddress;
-
     private String nickname;
 
     private String major;
 
-    private String phone;
-
-    private String email;
-
     private String introduction;
 
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "VARCHAR(20)")
     private UserStatus privacy;
 
+
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "VARCHAR(20)")
     private UserStatus status;
 
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "VARCHAR(20)")
     private UserRole role;
 
     private LocalDateTime createdAt;
@@ -70,17 +72,18 @@ public class UserEntity {
     private UniversityEntity homeUniversity;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="host_country_id")
+    private CountryEntity hostCountry;
+
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="nationality_id")
     private CountryEntity nationality;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name="region_id")
-    private RegionEntity region;
-
-    @OneToOne
+    @ManyToOne
     @JoinColumn(name="language_id")
     private LanguageEntity language;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<UserImageEntity> userImageEntityList = new ArrayList<>();
+
 }


### PR DESCRIPTION
`UserEntity`
  - 누락된 Annotation 추가
  - `hostCountry`: 유학국 추가
  - `@ManyToOne LanguageEntity`:  UserEntity와 LanguageEntity 연관관계 1:1에서 N:1로 수정
 

`UserAgreeEntity`
  - `id`: 기본키 추가를 위해 추가
  - `agree`: 약관 수락 여부 관리하기 위해 추가
 
`UniversityEntity`
  - `@ManyToOne RegionEntity`: 대학의 지역을 관리하기 위해 추가. RegionEntity와 University 연관관계 1:N로 수정

`TermsEntity`
  - `body`: 프론트에서 제공하기로 해서 제거

`RegionEntity`
  - `@OneToMany RegionEntity`: UniversityEntity 변경사항 내용과 동일

`LanguageEntity`
 - `@OneToMany UserEntity`: UserEntity 변경사항 내용과 동일
 
`CountryEntity`
 - `@OneToMany UserEntity`: UserEntity 변경사항 내용과 동일






