### PR TITLE
#26 [FEAT] 아이디, 닉네임 중복 체크 API 구현 완료

### DIFF
--- a/src/main/java/com/example/globalStudents/domain/user/controller/AuthController.java
+++ b/src/main/java/com/example/globalStudents/domain/user/controller/AuthController.java
@@ -1,0 +1,44 @@
+package com.example.globalStudents.domain.user.controller;
+
+import com.example.globalStudents.domain.user.dto.UserRequestDTO;
+import com.example.globalStudents.domain.user.dto.UserResponseDTO;
+import com.example.globalStudents.domain.user.service.UserService;
+import com.example.globalStudents.global.apiPayload.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final UserService userService;
+
+//    @PostMapping("/join/information")
+//    public ApiResponse<UserResponseDTO.JoinResultDTO> join(
+//            @RequestBody
+//            UserRequestDTO.JoinDTO joinDTO
+//    ){
+//        UserResponseDTO.JoinResultDTO user = userService.createUser(joinDTO);
+//        return ApiResponse.onCreated(user);
+//    }
+
+    @GetMapping("/join/check-id/{user_id}")
+    public ApiResponse<UserResponseDTO.CheckIdDTO> checkId(
+            @PathVariable
+            String user_id
+    ){
+        UserResponseDTO.CheckIdDTO id = userService.checkId(user_id);
+        return ApiResponse.onSuccess(id);
+    }
+
+    @GetMapping("/join/check-nickname/{user_nickname}")
+    public ApiResponse<UserResponseDTO.CheckNicknameDTO> checkNickname(
+            @PathVariable
+            String user_nickname
+    ){
+        UserResponseDTO.CheckNicknameDTO nickname = userService.checkNickname(user_nickname);
+        return ApiResponse.onCreated(nickname);
+    }
+
+}

--- a/src/main/java/com/example/globalStudents/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/globalStudents/domain/user/repository/UserRepository.java
@@ -1,0 +1,13 @@
+package com.example.globalStudents.domain.user.repository;
+
+import com.example.globalStudents.domain.user.entity.CountryEntity;
+import com.example.globalStudents.domain.user.entity.UniversityEntity;
+import com.example.globalStudents.domain.user.entity.UserEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<UserEntity,Long> {
+    Optional<UserEntity>findByUserId(String userId);
+    Optional<UserEntity>findByNickname(String nickname);
+}

--- a/src/main/java/com/example/globalStudents/domain/user/service/UserService.java
+++ b/src/main/java/com/example/globalStudents/domain/user/service/UserService.java
@@ -1,0 +1,13 @@
+package com.example.globalStudents.domain.user.service;
+
+import com.example.globalStudents.domain.user.dto.UserRequestDTO;
+import com.example.globalStudents.domain.user.dto.UserResponseDTO;
+
+public interface UserService {
+
+//    public UserResponseDTO.JoinResultDTO createUser(UserRequestDTO.JoinDTO joinDTO);
+
+    public UserResponseDTO.CheckIdDTO checkId(String userId);
+
+    public UserResponseDTO.CheckNicknameDTO checkNickname(String nickname);
+}

--- a/src/main/java/com/example/globalStudents/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/example/globalStudents/domain/user/service/UserServiceImpl.java
@@ -1,0 +1,84 @@
+package com.example.globalStudents.domain.user.service;
+
+import com.example.globalStudents.domain.user.converter.Converter;
+import com.example.globalStudents.domain.user.dto.UserRequestDTO;
+import com.example.globalStudents.domain.user.dto.UserResponseDTO;
+import com.example.globalStudents.domain.user.entity.TermsEntity;
+import com.example.globalStudents.domain.user.entity.UserAgreeEntity;
+import com.example.globalStudents.domain.user.entity.UserEntity;
+import com.example.globalStudents.domain.user.repository.TermsRepository;
+import com.example.globalStudents.domain.user.repository.UserAgreeRepository;
+import com.example.globalStudents.domain.user.repository.UserRepository;
+import com.example.globalStudents.global.apiPayload.code.status.ErrorStatus;
+import com.example.globalStudents.global.apiPayload.exception.handler.ExceptionHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+
+    private final Converter<UserEntity,UserRequestDTO.JoinDTO,UserResponseDTO.JoinResultDTO> converter;
+    private final UserRepository userRepository;
+    private final UserAgreeRepository userAgreeRepository;
+    private  final TermsRepository termsRepository;
+
+//    @Override
+//    public UserResponseDTO.JoinResultDTO createUser(UserRequestDTO.JoinDTO joinDTO) {
+//        var userEntity = converter.toEntity(joinDTO);
+//        var newEntity = userRepository.save(userEntity);
+//        if(joinDTO.getTerms()){
+//            TermsEntity termsEntity = termsRepository.findByName("terms").get();
+//            UserAgreeEntity userAgreeEntity = UserAgreeEntity.builder()
+//                    .user(newEntity)
+//                    .terms(termsEntity)
+//                    .createdAt(LocalDateTime.now())
+//                    .agree(true)
+//                    .build();
+//            userAgreeRepository.save(userAgreeEntity);
+//        }
+//        if(joinDTO.getPrivacy()){
+//            UserAgreeEntity userAgreeEntity = UserAgreeEntity.builder()
+//                    .user(newEntity)
+//                    .terms(termsRepository.findByName("privacy").get())
+//                    .createdAt(LocalDateTime.now())
+//                    .agree(true)
+//                    .build();
+//            userAgreeRepository.save(userAgreeEntity);
+//        }
+//        if(joinDTO.getMarketing()){
+//            UserAgreeEntity userAgreeEntity = UserAgreeEntity.builder()
+//                    .user(newEntity)
+//                    .terms(termsRepository.findByName("marketing").get())
+//                    .createdAt(LocalDateTime.now())
+//                    .agree(true)
+//                    .build();
+//            userAgreeRepository.save(userAgreeEntity);
+//        }
+//        return converter.toResponse(newEntity);
+//    }
+
+    @Override
+    public UserResponseDTO.CheckIdDTO checkId(String userId) {
+        if(userRepository.findByUserId(userId).isEmpty()){
+            return UserResponseDTO.CheckIdDTO.builder()
+                    .userId(userId)
+                    .build();
+        } else{
+            throw new ExceptionHandler(ErrorStatus.JOIN_ID_ALREADY_EXIST);
+        }
+    }
+
+    @Override
+    public UserResponseDTO.CheckNicknameDTO checkNickname(String nickname) {
+        if(userRepository.findByNickname(nickname).isEmpty()){
+            return UserResponseDTO.CheckNicknameDTO.builder()
+                    .nickname(nickname)
+                    .build();
+        } else{
+            throw new ExceptionHandler(ErrorStatus.JOIN_NICKNAME_ALREADY_EXIST);
+        }
+    }
+}


### PR DESCRIPTION
`AuthController`
  - `checkId`: Id 중복 체크 api
  - `checkNickname`: nickname 중복 체크 api

`UserRepositry`
  - 메소드명으로 JPQL 쿼리문 생성하는 방식
  - `findByUserId`:  db에서 유저 id로 entity 찾는 쿼리문
  - `findByNickname`: db에서 유저 nickname으로 entity 찾는 쿼리문

`UserService`
  - `checkId `: db에서 찾은 entity가 없을때 `CheckIdDTO` response에 id 담아서 반환
  - `checkNickname `: db에서 찾은 entity가 없을때 `CheckNicknameDTO` response에 id 담아서 반환