### PR TITLE
#31 [FEAT] UserConverter 구현 완료

### DIFF
--- a/src/main/java/com/example/globalStudents/domain/user/converter/Converter.java
+++ b/src/main/java/com/example/globalStudents/domain/user/converter/Converter.java
@@ -1,0 +1,8 @@
+package com.example.globalStudents.domain.user.converter;
+
+public interface Converter <T,M,K>{
+    public T toEntity(M dto);
+
+    public K toResponse(T entity);
+}
+

--- a/src/main/java/com/example/globalStudents/domain/user/converter/UserConverterImpl.java
+++ b/src/main/java/com/example/globalStudents/domain/user/converter/UserConverterImpl.java
@@ -1,0 +1,64 @@
+package com.example.globalStudents.domain.user.converter;
+
+import com.example.globalStudents.domain.user.dto.UserRequestDTO;
+import com.example.globalStudents.domain.user.dto.UserResponseDTO;
+import com.example.globalStudents.domain.user.entity.UserEntity;
+import com.example.globalStudents.domain.user.enums.UserRole;
+import com.example.globalStudents.domain.user.enums.UserStatus;
+import com.example.globalStudents.domain.user.repository.CountryRepository;
+import com.example.globalStudents.domain.user.repository.LanguageRepository;
+import com.example.globalStudents.domain.user.repository.UniversityRepository;
+import com.example.globalStudents.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.util.Date;
+
+@Service
+@RequiredArgsConstructor
+public class UserConverterImpl implements Converter <UserEntity,UserRequestDTO.JoinDTO,UserResponseDTO.JoinResultDTO>{
+
+    private final CountryRepository countryRepository;
+    private final UserRepository userRepository;
+    private final LanguageRepository languageRepository;
+    private final UniversityRepository universityRepository;
+    public UserEntity toEntity(UserRequestDTO.JoinDTO joinDTO){
+
+        return UserEntity.builder()
+                .hostUniversity(universityRepository.findByName(joinDTO.getHostUniversity()).get())
+                .homeUniversity(universityRepository.findByName(joinDTO.getHostUniversity()).get())
+                .hostCountry(countryRepository.findByName(joinDTO.getHostCountry()).get())
+                .nationality(countryRepository.findByName(joinDTO.getNationality()).get())
+                .language(languageRepository.findByName("English").get())
+                .uid(generateUID())
+                .userId(joinDTO.getUserId())
+                .password(joinDTO.getPassword())
+                .firstName(joinDTO.getFirstName())
+                .lastName(joinDTO.getLastName())
+                .birth(LocalDateTime.now())
+                .nickname(joinDTO.getNickname())
+                .status(UserStatus.REGISTERED)
+                .privacy(UserStatus.PUBLIC)
+                .role(UserRole.USER)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+    }
+
+    public UserResponseDTO.JoinResultDTO toResponse(UserEntity userEntity){
+        return UserResponseDTO.JoinResultDTO.builder()
+                .userId(userEntity.getUserId())
+                .nickname(userEntity.getNickname())
+                .nationality(userEntity.getNationality().getName())
+                .build();
+    }
+
+    public String generateUID(){
+        Date nowDate = new Date();
+        SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyyMMdd");
+        return "U_"+simpleDateFormat.format(nowDate)+"-"+(userRepository.count()+1);
+    }
+
+}

--- a/src/main/java/com/example/globalStudents/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/example/globalStudents/domain/user/service/UserServiceImpl.java
@@ -14,8 +14,6 @@ import com.example.globalStudents.global.apiPayload.exception.handler.ExceptionH
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
-
 @Service
 @RequiredArgsConstructor
 public class UserServiceImpl implements UserService {


### PR DESCRIPTION
`Converter`: 컨버터 인터페이스
  - `toEntity`: request dto를 entity로
  - `toDTO`:  entity를 response dto로

`UserConverterImpl`: 컨버터 구현체
   - `generateUID`: 유저 고유번호 생성 메소드