### PR TITLE
#78 [FIX] Jwt 예외 처리 버그 수정 완료

### DIFF
--- a/src/main/java/com/example/globalStudents/global/apiPayload/exception/TokenExceptionAdvice.java
+++ b/src/main/java/com/example/globalStudents/global/apiPayload/exception/TokenExceptionAdvice.java
@@ -4,6 +4,7 @@ import com.example.globalStudents.global.apiPayload.ApiResponse;
 import com.example.globalStudents.global.apiPayload.code.ErrorReasonDTO;
 import com.example.globalStudents.global.apiPayload.code.status.ErrorStatus;
 import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.security.SignatureException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -26,40 +27,38 @@ import java.util.Map;
 @RestControllerAdvice
 public class TokenExceptionAdvice extends ResponseEntityExceptionHandler{
 
-    @org.springframework.web.bind.annotation.ExceptionHandler(InsufficientAuthenticationException.class)
+    @org.springframework.web.bind.annotation.ExceptionHandler(JwtException.class)
     public ResponseEntity<Object> handleInsufficientAuthenticationException(Exception e, WebRequest request) {
-        e.printStackTrace();
 
-        return handleExceptionInternalFalse(e, ErrorStatus._UNAUTHORIZED, HttpHeaders.EMPTY, ErrorStatus._UNAUTHORIZED.getHttpStatus(),request, e.getMessage());
+        return handleExceptionInternalFalse(e, ErrorStatus._UNAUTHORIZED, HttpHeaders.EMPTY, ErrorStatus._UNAUTHORIZED.getHttpStatus(),request, "General Token Error");
     }
-
 
     @org.springframework.web.bind.annotation.ExceptionHandler(SignatureException.class)
     public ResponseEntity<Object> handleSignatureException(Exception e, WebRequest request) {
         e.printStackTrace();
 
-        return handleExceptionInternalFalse(e, ErrorStatus._UNAUTHORIZED, HttpHeaders.EMPTY, ErrorStatus._UNAUTHORIZED.getHttpStatus(),request, e.getMessage());
+        return handleExceptionInternalFalse(e, ErrorStatus._UNAUTHORIZED, HttpHeaders.EMPTY, ErrorStatus._UNAUTHORIZED.getHttpStatus(),request, "Token Not Valid");
     }
 
     @org.springframework.web.bind.annotation.ExceptionHandler(MalformedJwtException.class)
     public ResponseEntity<Object> handleMalformedJwtException(Exception e, WebRequest request) {
-        e.printStackTrace();
 
-        return handleExceptionInternalFalse(e, ErrorStatus._UNAUTHORIZED, HttpHeaders.EMPTY, ErrorStatus._UNAUTHORIZED.getHttpStatus(),request, e.getMessage());
+
+        return handleExceptionInternalFalse(e, ErrorStatus._UNAUTHORIZED, HttpHeaders.EMPTY, ErrorStatus._UNAUTHORIZED.getHttpStatus(),request, "Token Not Valid");
     }
 
     @org.springframework.web.bind.annotation.ExceptionHandler(ExpiredJwtException.class)
     public ResponseEntity<Object> handleExpiredJwtException(Exception e, WebRequest request) {
-        e.printStackTrace();
 
-        return handleExceptionInternalFalse(e, ErrorStatus._UNAUTHORIZED, HttpHeaders.EMPTY, ErrorStatus._UNAUTHORIZED.getHttpStatus(),request, e.getMessage());
+
+        return handleExceptionInternalFalse(e, ErrorStatus._UNAUTHORIZED, HttpHeaders.EMPTY, ErrorStatus._UNAUTHORIZED.getHttpStatus(),request, "Token Expired");
     }
 
     private ResponseEntity<Object> handleExceptionInternal(Exception e, ErrorReasonDTO reason,
                                                            HttpHeaders headers, HttpServletRequest request) {
 
         ApiResponse<Object> body = ApiResponse.onFailure(reason.getCode(),reason.getMessage(),null);
-//        e.printStackTrace();
+
 
         WebRequest webRequest = new ServletWebRequest(request);
 

--- a/src/main/java/com/example/globalStudents/global/auth/filter/JwtFilter.java
+++ b/src/main/java/com/example/globalStudents/global/auth/filter/JwtFilter.java
@@ -4,6 +4,7 @@ import com.example.globalStudents.domain.user.entity.UserEntity;
 import com.example.globalStudents.domain.user.enums.UserRole;
 import com.example.globalStudents.global.auth.jwt.CustomUserDetails;
 import com.example.globalStudents.global.util.JWTUtil;
+import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -33,9 +34,8 @@ public class JwtFilter extends OncePerRequestFilter {
 
             if (authorization == null || !authorization.startsWith("Bearer ")) {
 
-                filterChain.doFilter(request, response);
+                throw new JwtException("Token Null");
 
-                return;
             }
 
             String token = authorization.split(" ")[1];


### PR DESCRIPTION
`JwtFilter`: request header "Authorization" 필드가 null일 때 인증 성공하는 버그 수정