### PR TITLE
#82 [FEAT] 관리자 토큰 인가 구현 완료

### DIFF
--- a/src/main/java/com/example/globalStudents/global/auth/SecurityConfig.java
+++ b/src/main/java/com/example/globalStudents/global/auth/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.example.globalStudents.global.auth;
 
+import com.example.globalStudents.domain.user.enums.UserRole;
+import com.example.globalStudents.global.auth.filter.AuthenticationAccessDeniedHandler;
 import com.example.globalStudents.global.auth.filter.JwtFilter;
 import com.example.globalStudents.global.auth.filter.LoginFilter;
 import com.example.globalStudents.global.util.JWTUtil;
@@ -22,12 +24,15 @@ public class SecurityConfig {
     //AuthenticationManager가 인자로 받을 AuthenticationConfiguraion 객체 생성자 주입
     private final AuthenticationConfiguration authenticationConfiguration;
 
+    private final AuthenticationAccessDeniedHandler accessDeniedHandler;
+
     private final AuthenticationEntryPoint entryPoint;
 
     private final JWTUtil jwtUtil;
-    public SecurityConfig(AuthenticationConfiguration authenticationConfiguration, AuthenticationEntryPoint entryPoint, JWTUtil jwtUtil) {
+    public SecurityConfig(AuthenticationConfiguration authenticationConfiguration, AuthenticationAccessDeniedHandler accessDeniedHandler, AuthenticationEntryPoint entryPoint, JWTUtil jwtUtil) {
 
         this.authenticationConfiguration = authenticationConfiguration;
+        this.accessDeniedHandler = accessDeniedHandler;
         this.entryPoint = entryPoint;
         this.jwtUtil = jwtUtil;
     }
@@ -59,8 +64,8 @@ public class SecurityConfig {
 
         http
                 .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/", "/error","/v3/**", "/swagger-ui/**","/auth/join/**","/user/**").permitAll()
-                        .requestMatchers("/admin/**").hasAuthority("ADMIN")
+                        .requestMatchers("/", "/error","/v3/**", "/swagger-ui/**","/auth/**","/user/**").permitAll()
+                        .requestMatchers("admin/**").hasAuthority(UserRole.ADMIN.name())
                         .anyRequest().authenticated());
 
         http
@@ -71,7 +76,8 @@ public class SecurityConfig {
 
         http
                 .exceptionHandling()
-                    .authenticationEntryPoint(entryPoint);
+                .authenticationEntryPoint(entryPoint)
+                .accessDeniedHandler(accessDeniedHandler);
 
         http
                 .sessionManagement((session) -> session

--- a/src/main/java/com/example/globalStudents/global/auth/filter/AuthenticationAccessDeniedHandler.java
+++ b/src/main/java/com/example/globalStudents/global/auth/filter/AuthenticationAccessDeniedHandler.java
@@ -1,0 +1,31 @@
+package com.example.globalStudents.global.auth.filter;
+
+import com.example.globalStudents.global.apiPayload.ApiResponse;
+import com.example.globalStudents.global.apiPayload.code.status.ErrorStatus;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class AuthenticationAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        setUnsuccessfulResponse(response);
+    }
+
+    private void setUnsuccessfulResponse(HttpServletResponse response) throws IOException {
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setContentType("application/json;charset=UTF-8");
+        ObjectMapper mapper = new ObjectMapper();
+        String text = mapper.writeValueAsString(ApiResponse.onFailure(ErrorStatus._FORBIDDEN.getCode().toString(),ErrorStatus._FORBIDDEN.getMessage(),""));
+
+        response.getWriter().print(text);
+    }
+}


### PR DESCRIPTION
`SecurityConfig`
   - `.requestMatchers("admin/**").hasAuthority(UserRole.ADMIN.name())`: jwt 토큰 role이 ADMIN일 때만 "/admin/**"에 접근 가능하도록 설정

`AuthenticationAccessDeniedHandler`: 403 접근 불가 에러가 발생했을때 response를 커스터마이징하여 처리