### PR TITLE
#104 [FEAT] 유저 인증 및 정지 관리자 페이지 기능 구현 완료

### DIFF
--- a/src/main/java/com/example/globalStudents/domain/admin/user/controller/AdminUserController.java
+++ b/src/main/java/com/example/globalStudents/domain/admin/user/controller/AdminUserController.java
@@ -5,10 +5,7 @@ import com.example.globalStudents.domain.user.dto.UserResponseDTO;
 import com.example.globalStudents.domain.user.entity.UserEntity;
 import com.example.globalStudents.global.apiPayload.ApiResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 
 @RestController
@@ -25,5 +22,25 @@ public class AdminUserController {
         UserResponseDTO.AllUsersResultDTO userList = adminUserService.getAllUsers(filtering_type);
 
         return ApiResponse.onSuccess(userList);
+    }
+
+    @PostMapping("/users/{user_id}/verification")
+    public ApiResponse<String> verifyUser(
+            @PathVariable
+            String user_id
+    ){
+        adminUserService.verifyUser(user_id);
+
+        return ApiResponse.onSuccess(" ");
+    }
+
+    @PostMapping("/users/{user_id}/ban")
+    public ApiResponse<UserResponseDTO.BanResultDTO> banUser(
+            @PathVariable
+            String user_id
+    ){
+        UserResponseDTO.BanResultDTO banResultDTO = adminUserService.banUser(user_id);
+
+        return ApiResponse.onSuccess(banResultDTO);
     }
 }

--- a/src/main/java/com/example/globalStudents/domain/admin/user/converter/AdminConverterImpl.java
+++ b/src/main/java/com/example/globalStudents/domain/admin/user/converter/AdminConverterImpl.java
@@ -30,6 +30,11 @@ public class AdminConverterImpl implements AdminConverter {
         List<UserImageEntity> imageList = userImageRepository.findByUserIdAndType(userEntity.getId(), ImageType.University);
         int countReport = reportRepository.countAllByReportedUser(userEntity);
 
+        String isBanned = UserStatus.REGISTERED.getDescription();
+        if(userEntity.getStatus()==UserStatus.BANNED){
+            isBanned = UserStatus.BANNED.getDescription();
+        }
+
         return UserResponseDTO.UserDetailInfoResultDTO.builder()
                 .uid(userEntity.getUid())
                 .userId(userEntity.getUserId())
@@ -41,9 +46,10 @@ public class AdminConverterImpl implements AdminConverter {
                 .hostUniversity(userEntity.getHostUniversity().getName())
                 .homeUniversity(userEntity.getHomeUniversity().getName())
                 .fileName(imageList.get(imageList.size() - 1).getImageName())
-                .fileName(imageList.get(imageList.size() - 1).getImageName())
+                .fileUrl(imageList.get(imageList.size() - 1).getImageUrl())
                 .isVerified(userEntity.getVerification().getDescription())
                 .countReport(countReport)
+                .isBanned(isBanned)
                 .createdAt(userEntity.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
                 .build();
 

--- a/src/main/java/com/example/globalStudents/domain/admin/user/service/AdminUserService.java
+++ b/src/main/java/com/example/globalStudents/domain/admin/user/service/AdminUserService.java
@@ -7,4 +7,8 @@ import java.util.List;
 
 public interface AdminUserService {
     public UserResponseDTO.AllUsersResultDTO getAllUsers(String filtering_type);
+
+    public void verifyUser(String userId);
+
+    public UserResponseDTO.BanResultDTO banUser(String userId);
 }

--- a/src/main/java/com/example/globalStudents/domain/admin/user/service/AdminUserServiceImpl.java
+++ b/src/main/java/com/example/globalStudents/domain/admin/user/service/AdminUserServiceImpl.java
@@ -3,16 +3,56 @@ package com.example.globalStudents.domain.admin.user.service;
 import com.example.globalStudents.domain.admin.user.converter.AdminConverter;
 import com.example.globalStudents.domain.user.dto.UserResponseDTO;
 import com.example.globalStudents.domain.user.entity.UserEntity;
+import com.example.globalStudents.domain.user.enums.UserStatus;
+import com.example.globalStudents.domain.user.repository.UserRepository;
+import com.example.globalStudents.global.apiPayload.code.status.ErrorStatus;
+import com.example.globalStudents.global.apiPayload.exception.handler.ExceptionHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class AdminUserServiceImpl implements AdminUserService{
 
     private final AdminConverter userConverter;
+    private final UserRepository userRepository;
     @Override
     public UserResponseDTO.AllUsersResultDTO getAllUsers(String filtering_type) {
         return userConverter.toResponseList(filtering_type);
+    }
+
+    @Override
+    @Transactional
+    public void verifyUser(String userId) {
+        Optional<UserEntity> userEntity = userRepository.findByUserId(userId);
+        if(userEntity.isPresent()){
+            userEntity.get().setVerification(UserStatus.VERIFIED);
+        } else{
+            throw new ExceptionHandler(ErrorStatus._BAD_REQUEST);
+        }
+    }
+
+    @Override
+    @Transactional
+    public UserResponseDTO.BanResultDTO banUser(String userId) {
+        Optional<UserEntity> userEntity = userRepository.findByUserId(userId);
+        if(userEntity.isPresent()){
+            if(userEntity.get().getStatus()!=UserStatus.BANNED){
+                userEntity.get().setStatus(UserStatus.BANNED);
+                return UserResponseDTO.BanResultDTO.builder()
+                        .ban(true)
+                        .build();
+            } else {
+                userEntity.get().setStatus(UserStatus.REGISTERED);
+                return UserResponseDTO.BanResultDTO.builder()
+                        .ban(false)
+                        .build();
+            }
+        } else{
+            throw new ExceptionHandler(ErrorStatus._BAD_REQUEST);
+        }
     }
 }

--- a/src/main/java/com/example/globalStudents/domain/user/dto/UserResponseDTO.java
+++ b/src/main/java/com/example/globalStudents/domain/user/dto/UserResponseDTO.java
@@ -93,6 +93,7 @@ public class UserResponseDTO {
         String fileName;
         String fileUrl;
         String isVerified;
+        String isBanned;
         Integer countReport;
         String createdAt;
     }
@@ -124,6 +125,14 @@ public class UserResponseDTO {
         String accessToken;
         @JsonFormat(pattern="yyyy-MM-dd'T'HH:mm:ss")
         Date expireAt;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class BanResultDTO{
+        boolean ban; // true는 정지 처리 false는 정지 풀림
     }
 
 

--- a/src/main/java/com/example/globalStudents/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/globalStudents/global/apiPayload/code/status/ErrorStatus.java
@@ -43,6 +43,7 @@ public enum ErrorStatus implements BaseErrorCode {
     REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "TOKEN401_4", "만료된 refresh 토큰입니다"),
     COOKIE_NOT_FOUND(HttpStatus.UNAUTHORIZED, "COOKIE400_1", "쿠키에 refresh 토큰이 없습니다"),
     TOKEN_NOT_EXPIRED(HttpStatus.UNAUTHORIZED, "TOKEN400_1", "유효한 토큰입니다"),
+    BANNED(HttpStatus.UNAUTHORIZED, "ACCOUNT400_1", "잠긴 계정입니다"),
 
     // Chat error
     CHAT_NOT_FOUND(HttpStatus.BAD_REQUEST, "CHAT400_1", "채팅방을 불러올 수 없습니다. - 채팅방이 조회되지 않는 경우"),

--- a/src/main/java/com/example/globalStudents/global/auth/SecurityConfig.java
+++ b/src/main/java/com/example/globalStudents/global/auth/SecurityConfig.java
@@ -91,7 +91,7 @@ public class SecurityConfig {
                 .addFilterBefore(new JwtFilter(jwtUtil), LoginFilter.class);
         //필터 추가 LoginFilter()는 인자를 받음 (AuthenticationManager() 메소드에 authenticationConfiguration 객체를 넣어야 함) 따라서 등록 필요
         http
-                .addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration), jwtUtil), UsernamePasswordAuthenticationFilter.class);
+                .addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration), jwtUtil, objectMapper, boardRepository, redisUtil), UsernamePasswordAuthenticationFilter.class);
 
         http
                 .exceptionHandling()

--- a/src/main/java/com/example/globalStudents/global/auth/jwt/CustomUserDetails.java
+++ b/src/main/java/com/example/globalStudents/global/auth/jwt/CustomUserDetails.java
@@ -1,6 +1,7 @@
 package com.example.globalStudents.global.auth.jwt;
 
 import com.example.globalStudents.domain.user.entity.UserEntity;
+import com.example.globalStudents.domain.user.enums.UserStatus;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
@@ -47,7 +48,7 @@ public class CustomUserDetails implements UserDetails {
 
     @Override
     public boolean isAccountNonLocked() {
-        return true;
+        return userEntity.getStatus() != UserStatus.BANNED;
     }
 
     @Override


### PR DESCRIPTION
`AdminUserService`
   - `verifyUser()`: 유저 계정 학교 인증 처리 메소드
   - `banUser()`: 유저 계정 정지 및 정지 풀기 처리 메소드

`UserResponseDTO`
   - `BanResultDTO`: 정지면 true, 정지 풀기면 false 저장

`ErrorStatus`
   - `BANNED`: 정지 계정 로그인 처리시 에러 코드로 사용하는 enum
 
`CustomUserDetails`
  - `isAccountNonLocked()`: user status가 Banned면 false를 반환하여 AuthenticateManager의 authenticate 메소드에서 LockedException이 발생하도록 처리
  
`LoginFilter`
  - `AuthenticationException failed`가 `LockedException` 타입인 경우 정지 계정으로 분류하고 로그인 실패 처리
