### PR TITLE
#103 [FEAT] 신고 관리자 페이지 기능 구현 완료

### DIFF
--- a/src/main/java/com/example/globalStudents/domain/admin/report/controller/AdminReportController.java
+++ b/src/main/java/com/example/globalStudents/domain/admin/report/controller/AdminReportController.java
@@ -1,0 +1,44 @@
+package com.example.globalStudents.domain.admin.report.controller;
+
+import com.example.globalStudents.domain.admin.report.dto.AdminReportResponseDTO;
+import com.example.globalStudents.domain.admin.report.service.AdminReportService;
+import com.example.globalStudents.domain.board.dto.PostResponseDTO;
+import com.example.globalStudents.global.apiPayload.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin")
+public class AdminReportController {
+
+
+    private final AdminReportService adminReportService;
+
+    @GetMapping("/report")
+    public ApiResponse<AdminReportResponseDTO.ReportListResultDTO> getReportList() {
+
+        AdminReportResponseDTO.ReportListResultDTO reportList = adminReportService.getAllReports();
+
+        return ApiResponse.onSuccess(reportList);
+    }
+
+    @GetMapping("/report/{report_id}/handle")
+    public ApiResponse<AdminReportResponseDTO.HandleReportResultDTO> handleReport(
+            @PathVariable("report_id") Long reportId,
+            @RequestParam(name = "action") String handlingType) {
+
+        AdminReportResponseDTO.HandleReportResultDTO handleResult = adminReportService.handleReport(reportId, handlingType);
+
+        return ApiResponse.onSuccess(handleResult);
+    }
+
+    @GetMapping("/posts/{post_id}")
+    public ApiResponse<PostResponseDTO.GetPostResultDTO> getPost(
+            @PathVariable("post_id") Long postId
+    ) {
+        PostResponseDTO.GetPostResultDTO getAdminPostResultDTO = adminReportService.getPost(postId);
+
+        return ApiResponse.onSuccess(getAdminPostResultDTO);
+    }
+}

--- a/src/main/java/com/example/globalStudents/domain/admin/report/converter/AdminReportConverter.java
+++ b/src/main/java/com/example/globalStudents/domain/admin/report/converter/AdminReportConverter.java
@@ -1,0 +1,63 @@
+package com.example.globalStudents.domain.admin.report.converter;
+
+import com.example.globalStudents.domain.admin.report.dto.AdminReportResponseDTO;
+import com.example.globalStudents.domain.board.entity.ReportEntity;
+import com.example.globalStudents.domain.board.enums.ReportStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AdminReportConverter {
+
+    public static AdminReportResponseDTO.ReportListResultDTO toReportListResultDTO(
+            List<AdminReportResponseDTO.PostReportDTO> postReportDTOList,
+            List<AdminReportResponseDTO.CommentReportDTO> commentReportDTOList
+    ) {
+
+        return AdminReportResponseDTO.ReportListResultDTO.builder()
+                .postReportList(postReportDTOList)
+                .commentReportList(commentReportDTOList)
+                .build();
+    }
+
+    public static AdminReportResponseDTO.PostReportDTO toPostReportDTO(ReportEntity report, int reportCount) {
+        return AdminReportResponseDTO.PostReportDTO.builder()
+                .reportId(report.getId().toString())
+                .postTitle(report.getPost().getTitle())
+                .postUrl("/admin/posts/" + report.getPost().getId())
+                .authorId(report.getPost().getUid())
+                .reportDate(report.getPost().getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy.MM.dd")))
+                .postDate(report.getPost().getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy.MM.dd")))
+                .reportCount(reportCount)
+                .reportReason(report.getBody())
+                .isHandled((report.getStatus() == ReportStatus.RECEIVED) ? true : false)
+                .handledType(report.getHandleType().toString())
+                .build();
+    }
+
+    public static AdminReportResponseDTO.CommentReportDTO toCommentReportDTO(ReportEntity report, int reportCount) {
+        return AdminReportResponseDTO.CommentReportDTO.builder()
+                .reportId(report.getId().toString())
+                .commentContent(report.getComment().getBody())
+                .postUrl("/admin/posts/" + report.getComment().getPost().getId())
+                .postTitle(report.getComment().getPost().getTitle())
+                .authorId(report.getComment().getUser().getUserId())
+                .reportDate(report.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy.MM.dd")))
+                .reportCount(reportCount)
+                .reportReason(report.getBody())
+                .isHandled((report.getStatus() == ReportStatus.RECEIVED) ? true : false)
+                .handledType(report.getHandleType().toString())
+                .build();
+    }
+
+    public static AdminReportResponseDTO.HandleReportResultDTO toHandleReportResultDTO(ReportEntity report) {
+        return AdminReportResponseDTO.HandleReportResultDTO.builder()
+                .reportId(report.getId().toString())
+                .build();
+    }
+
+}

--- a/src/main/java/com/example/globalStudents/domain/admin/report/dto/AdminReportResponseDTO.java
+++ b/src/main/java/com/example/globalStudents/domain/admin/report/dto/AdminReportResponseDTO.java
@@ -1,0 +1,62 @@
+package com.example.globalStudents.domain.admin.report.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class AdminReportResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ReportListResultDTO {
+        private List<PostReportDTO> postReportList;
+        private List<CommentReportDTO> commentReportList;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PostReportDTO {
+        private String reportId;
+        private String postTitle;
+        private String postUrl;
+        private String authorId;
+        private String reportDate;
+        private String postDate;
+        private int reportCount;
+        private String reportReason;
+        private boolean isHandled;
+        private String handledType;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CommentReportDTO {
+        private String reportId;
+        private String commentContent;
+        private String postUrl;
+        private String postTitle;
+        private String authorId;
+        private String reportDate;
+        private int reportCount;
+        private String reportReason;
+        private boolean isHandled;
+        private String handledType;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class HandleReportResultDTO {
+        private String reportId;
+    }
+}

--- a/src/main/java/com/example/globalStudents/domain/admin/report/service/AdminReportService.java
+++ b/src/main/java/com/example/globalStudents/domain/admin/report/service/AdminReportService.java
@@ -1,0 +1,13 @@
+package com.example.globalStudents.domain.admin.report.service;
+
+import com.example.globalStudents.domain.admin.report.dto.AdminReportResponseDTO;
+import com.example.globalStudents.domain.board.dto.PostResponseDTO;
+
+public interface AdminReportService {
+
+    public AdminReportResponseDTO.ReportListResultDTO getAllReports();
+
+    public AdminReportResponseDTO.HandleReportResultDTO handleReport(Long reportId, String handlingType);
+
+    public PostResponseDTO.GetPostResultDTO getPost(Long postId);
+}

--- a/src/main/java/com/example/globalStudents/domain/admin/report/service/AdminReportServiceImpl.java
+++ b/src/main/java/com/example/globalStudents/domain/admin/report/service/AdminReportServiceImpl.java
@@ -1,0 +1,107 @@
+package com.example.globalStudents.domain.admin.report.service;
+
+import com.example.globalStudents.domain.admin.report.converter.AdminReportConverter;
+import com.example.globalStudents.domain.admin.report.dto.AdminReportResponseDTO;
+import com.example.globalStudents.domain.board.converter.PostConverter;
+import com.example.globalStudents.domain.board.dto.PostResponseDTO;
+import com.example.globalStudents.domain.board.entity.CommentEntity;
+import com.example.globalStudents.domain.board.entity.PostEntity;
+import com.example.globalStudents.domain.board.entity.ReportEntity;
+import com.example.globalStudents.domain.board.enums.*;
+import com.example.globalStudents.domain.board.repository.CommentRepository;
+import com.example.globalStudents.domain.board.repository.PostRepository;
+import com.example.globalStudents.domain.board.repository.ReportRepository;
+import com.example.globalStudents.global.apiPayload.code.status.ErrorStatus;
+import com.example.globalStudents.global.apiPayload.exception.handler.ExceptionHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AdminReportServiceImpl implements AdminReportService{
+
+    private final ReportRepository reportRepository;
+    private final CommentRepository commentRepository;
+    private final PostRepository postRepository;
+
+    @Override
+    public AdminReportResponseDTO.ReportListResultDTO getAllReports() {
+
+        List<ReportEntity> postReportList = reportRepository.findByTypeOrderedByReportStatus(ReportType.POST);
+        List<ReportEntity> commentReportList = reportRepository.findByTypeOrderedByReportStatus(ReportType.COMMENT);
+
+        List<AdminReportResponseDTO.PostReportDTO> postReportDTOList = postReportList.stream()
+                .map(
+                        report -> {
+                            return AdminReportConverter.toPostReportDTO(report, reportRepository.countAllByPost(report.getPost()));
+                        }
+                ).collect(Collectors.toList());
+
+        List<AdminReportResponseDTO.CommentReportDTO> commentReportDTOList = commentReportList.stream()
+                .map(
+                        report -> {
+                            return AdminReportConverter.toCommentReportDTO(report, reportRepository.countAllByComment(report.getComment()));
+                        }
+                ).collect(Collectors.toList());
+
+        return AdminReportConverter.toReportListResultDTO(postReportDTOList, commentReportDTOList);
+    }
+
+    @Override
+    public AdminReportResponseDTO.HandleReportResultDTO handleReport(Long reportId, String handlingType) {
+        ReportEntity report = reportRepository.findById(reportId)
+                .orElseThrow(()->new ExceptionHandler(ErrorStatus._BAD_REQUEST));
+
+        //중복 처리 확인
+        if (report.getStatus() == ReportStatus.RECEIVED) {
+            throw new ExceptionHandler(ErrorStatus.ADMIN_ALREADY_HANDLED_REPORT);
+        }
+
+        if (handlingType.equals("delete")) {
+            //게시글 DELETED status로 변경
+            if (report.getType() == ReportType.POST) {
+                PostEntity post = report.getPost();
+                post.setStatus(PostStatus.DELETED);
+                post.setDeletedAt(LocalDateTime.now());
+                postRepository.save(post);
+            }
+            //댓글 DELETED status로 변경
+            else if (report.getType() == ReportType.COMMENT) {
+                CommentEntity comment = report.getComment();
+                comment.setStatus(CommentStatus.DELETED);
+                comment.setDeletedAt(LocalDateTime.now());
+                commentRepository.save(comment);
+            }
+            else {
+                throw new ExceptionHandler(ErrorStatus._BAD_REQUEST);
+            }
+
+            report.setHandleType(ReportHandleType.DELETE);
+
+        } else if (handlingType.equals("maintain")) {
+            report.setHandleType(ReportHandleType.MAINTAIN);
+        }
+        else {
+            throw new ExceptionHandler(ErrorStatus._BAD_REQUEST);
+        }
+
+        report.setStatus(ReportStatus.RECEIVED);
+
+        return AdminReportConverter.toHandleReportResultDTO(reportRepository.save(report));
+    }
+
+    @Override
+    public PostResponseDTO.GetPostResultDTO getPost(Long postId) {
+        PostEntity post = postRepository.findById(postId)
+                .orElseThrow(()-> new ExceptionHandler(ErrorStatus.POST_NOT_FOUND));
+
+        return PostConverter.toAdminPostResult(post);
+    }
+
+}

--- a/src/main/java/com/example/globalStudents/domain/board/converter/BoardConverter.java
+++ b/src/main/java/com/example/globalStudents/domain/board/converter/BoardConverter.java
@@ -2,6 +2,7 @@ package com.example.globalStudents.domain.board.converter;
 
 import com.example.globalStudents.domain.board.dto.BoardResponseDTO;
 import com.example.globalStudents.domain.board.entity.PostEntity;
+import com.example.globalStudents.domain.board.enums.CommentStatus;
 import org.springframework.data.domain.Page;
 
 import java.time.format.DateTimeFormatter;
@@ -51,7 +52,7 @@ public class BoardConverter {
     public static BoardResponseDTO.PostDTO toPostDTO(PostEntity post) {
         return BoardResponseDTO.PostDTO.builder()
                 .title(post.getTitle())
-                .numberOfComments(post.getCommentList().size())
+                .numberOfComments(post.getCommentList().stream().filter(comment -> comment.getStatus() == CommentStatus.ACTIVE).collect(Collectors.toList()).size())
                 .date(post.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")))
                 .author((post.getIsAnonymous()) ? "익명" : post.getUid())
                 .likes(post.getLikes())

--- a/src/main/java/com/example/globalStudents/domain/board/converter/CommentConverter.java
+++ b/src/main/java/com/example/globalStudents/domain/board/converter/CommentConverter.java
@@ -4,6 +4,7 @@ import com.example.globalStudents.domain.board.dto.CommentRequestDTO;
 import com.example.globalStudents.domain.board.dto.CommentResponseDTO;
 import com.example.globalStudents.domain.board.entity.CommentEntity;
 import com.example.globalStudents.domain.board.entity.CommentLikeEntity;
+import com.example.globalStudents.domain.board.enums.CommentStatus;
 import com.example.globalStudents.domain.user.entity.UserEntity;
 
 import java.time.LocalDateTime;
@@ -21,6 +22,7 @@ public class CommentConverter {
                 .body(request.getContent())
                 .isAnonymous(request.getIsAnonymous())
                 .likes(0)
+                .status(CommentStatus.ACTIVE)
                 .createdAt(LocalDateTime.now())
                 .build();
     }

--- a/src/main/java/com/example/globalStudents/domain/board/converter/PostConverter.java
+++ b/src/main/java/com/example/globalStudents/domain/board/converter/PostConverter.java
@@ -3,6 +3,7 @@ package com.example.globalStudents.domain.board.converter;
 import com.example.globalStudents.domain.board.dto.PostRequestDTO;
 import com.example.globalStudents.domain.board.dto.PostResponseDTO;
 import com.example.globalStudents.domain.board.entity.*;
+import com.example.globalStudents.domain.board.enums.CommentStatus;
 import com.example.globalStudents.domain.board.enums.PostStatus;
 import com.example.globalStudents.domain.board.enums.UserPostReactionType;
 import com.example.globalStudents.domain.user.entity.UserEntity;
@@ -72,6 +73,7 @@ public class PostConverter {
 
     public static List<PostResponseDTO.CommentDTO> toPostCommentList(List<CommentEntity> commentList) {
         return commentList.stream()
+                .filter(comment -> comment.getStatus().equals(CommentStatus.ACTIVE))
                 .map(comment -> {
                     return PostResponseDTO.CommentDTO.builder()
                             .userId(comment.getUser().getUserId())
@@ -103,5 +105,36 @@ public class PostConverter {
                 .build();
     }
 
+    public static PostResponseDTO.GetPostResultDTO toAdminPostResult(PostEntity post) {
+        return PostResponseDTO.GetPostResultDTO.builder()
+                .postId(post.getId().toString())
+                .title(post.getTitle())
+                .date(post.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")))
+                .userId(post.getUid())
+                .userNickname(post.getUser().getNickname())
+                .isAnonymous(post.getIsAnonymous())
+                .views(post.getView())
+                .images(toPostImageList(post.getPostImageList()))
+                .likes(post.getLikes())
+                .bookmarks(post.getBookmarks())
+                .content(post.getBody())
+                .comment(toAdmimPostCommentList(post.getCommentList()))
+                .build();
+    }
+
+    public static List<PostResponseDTO.CommentDTO> toAdmimPostCommentList(List<CommentEntity> commentList) {
+        return commentList.stream()
+                .map(comment -> {
+                    return PostResponseDTO.CommentDTO.builder()
+                            .userId(comment.getUser().getUserId())
+                            .nickname(comment.getUser().getNickname())
+                            .isAnonymous(comment.getIsAnonymous())
+                            .content(comment.getBody())
+                            .likes(comment.getLikes())
+                            .commentId(comment.getId().toString())
+                            .date(comment.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")))
+                            .build();
+                }).collect(Collectors.toList());
+    }
 
 }

--- a/src/main/java/com/example/globalStudents/domain/board/converter/ReportConverter.java
+++ b/src/main/java/com/example/globalStudents/domain/board/converter/ReportConverter.java
@@ -5,6 +5,7 @@ import com.example.globalStudents.domain.board.dto.ReportResponseDTO;
 import com.example.globalStudents.domain.board.entity.CommentEntity;
 import com.example.globalStudents.domain.board.entity.PostEntity;
 import com.example.globalStudents.domain.board.entity.ReportEntity;
+import com.example.globalStudents.domain.board.enums.ReportHandleType;
 import com.example.globalStudents.domain.board.enums.ReportStatus;
 import com.example.globalStudents.domain.board.enums.ReportType;
 import com.example.globalStudents.domain.user.entity.UserEntity;
@@ -21,6 +22,7 @@ public class ReportConverter {
                 .type(ReportType.POST)
                 .body(request.getBody())
                 .status(ReportStatus.NOT_RECEIVED)
+                .handleType(ReportHandleType.NOT_HANDLED)
                 .createdAt(LocalDateTime.now())
                 .build();
     }
@@ -33,6 +35,7 @@ public class ReportConverter {
                 .type(ReportType.COMMENT)
                 .body(request.getBody())
                 .status(ReportStatus.NOT_RECEIVED)
+                .handleType(ReportHandleType.NOT_HANDLED)
                 .createdAt(LocalDateTime.now())
                 .build();
     }

--- a/src/main/java/com/example/globalStudents/domain/board/entity/CommentEntity.java
+++ b/src/main/java/com/example/globalStudents/domain/board/entity/CommentEntity.java
@@ -1,5 +1,6 @@
 package com.example.globalStudents.domain.board.entity;
 
+import com.example.globalStudents.domain.board.enums.CommentStatus;
 import com.example.globalStudents.domain.user.entity.UserEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -29,8 +30,15 @@ public class CommentEntity {
     @Column(nullable = false)
     private Integer likes;
 
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "VARCHAR(20)")
+    private CommentStatus status;
+
     @Column(columnDefinition = "DATETIME(6)")
     private LocalDateTime createdAt;
+
+    @Column(columnDefinition = "DATETIME(6)")
+    private LocalDateTime deletedAt;
 
     @ManyToOne
     @JoinColumn(name = "user_id")
@@ -60,6 +68,14 @@ public class CommentEntity {
         }
         this.post = post;
         post.getCommentList().add(this);
+    }
+
+    public void setStatus(CommentStatus status) {
+        this.status = status;
+    }
+
+    public void setDeletedAt(LocalDateTime deletedAt) {
+        this.deletedAt = deletedAt;
     }
 
     public void incrementLikes() {

--- a/src/main/java/com/example/globalStudents/domain/board/entity/PostEntity.java
+++ b/src/main/java/com/example/globalStudents/domain/board/entity/PostEntity.java
@@ -107,6 +107,14 @@ public class PostEntity {
         this.updatedAt = updatedAt;
     }
 
+    public void setStatus(PostStatus status) {
+        this.status = status;
+    }
+
+    public void setDeletedAt(LocalDateTime deletedAt) {
+        this.deletedAt = deletedAt;
+    }
+
     public void incrementView() {
         this.view++;
     }

--- a/src/main/java/com/example/globalStudents/domain/board/entity/ReportEntity.java
+++ b/src/main/java/com/example/globalStudents/domain/board/entity/ReportEntity.java
@@ -1,5 +1,6 @@
 package com.example.globalStudents.domain.board.entity;
 
+import com.example.globalStudents.domain.board.enums.ReportHandleType;
 import com.example.globalStudents.domain.board.enums.ReportStatus;
 import com.example.globalStudents.domain.board.enums.ReportType;
 import com.example.globalStudents.domain.user.entity.UserEntity;
@@ -30,6 +31,10 @@ public class ReportEntity {
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "VARCHAR(20)")
     private ReportStatus status;
+
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "VARCHAR(20)")
+    private ReportHandleType handleType;
 
     @Column(columnDefinition = "DATETIME(6)")
     private LocalDateTime createdAt;
@@ -80,5 +85,13 @@ public class ReportEntity {
         }
         this.comment = comment;
         comment.getReportList().add(this);
+    }
+
+    public void setHandleType(ReportHandleType handleType) {
+        this.handleType = handleType;
+    }
+
+    public void setStatus(ReportStatus status) {
+        this.status = status;
     }
 }

--- a/src/main/java/com/example/globalStudents/domain/board/enums/CommentStatus.java
+++ b/src/main/java/com/example/globalStudents/domain/board/enums/CommentStatus.java
@@ -1,0 +1,5 @@
+package com.example.globalStudents.domain.board.enums;
+
+public enum CommentStatus {
+    ACTIVE, DELETED
+}

--- a/src/main/java/com/example/globalStudents/domain/board/enums/ReportHandleType.java
+++ b/src/main/java/com/example/globalStudents/domain/board/enums/ReportHandleType.java
@@ -1,0 +1,5 @@
+package com.example.globalStudents.domain.board.enums;
+
+public enum ReportHandleType {
+    NOT_HANDLED, MAINTAIN, DELETE
+}

--- a/src/main/java/com/example/globalStudents/domain/board/repository/ReportRepository.java
+++ b/src/main/java/com/example/globalStudents/domain/board/repository/ReportRepository.java
@@ -3,8 +3,11 @@ package com.example.globalStudents.domain.board.repository;
 import com.example.globalStudents.domain.board.entity.CommentEntity;
 import com.example.globalStudents.domain.board.entity.PostEntity;
 import com.example.globalStudents.domain.board.entity.ReportEntity;
+import com.example.globalStudents.domain.board.enums.ReportType;
 import com.example.globalStudents.domain.user.entity.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -15,4 +18,11 @@ public interface ReportRepository extends JpaRepository<ReportEntity, Long> {
     List<ReportEntity> findByReportUserAndPost(UserEntity reportUser, PostEntity post);
 
     int countAllByReportedUser(UserEntity reportedUser);
+
+    @Query("SELECT r FROM ReportEntity r WHERE r.type = :reportType ORDER BY CASE WHEN r.status = 'NOT_RECEIVED' THEN  0 ELSE 1 END")
+    List<ReportEntity> findByTypeOrderedByReportStatus(@Param("reportType") ReportType reportType);
+
+    int countAllByPost(PostEntity post);
+
+    int countAllByComment(CommentEntity comment);
 }

--- a/src/main/java/com/example/globalStudents/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/globalStudents/global/apiPayload/code/status/ErrorStatus.java
@@ -71,7 +71,10 @@ public enum ErrorStatus implements BaseErrorCode {
     REPORT_ALREADY_REPORTED(HttpStatus.BAD_REQUEST, "REPORT403_2", "이미 신고한 내용입니다 - 댓글 또는 게시글을 이미 신고한 경우"),
     POST_IMAGE_ID_INVALID(HttpStatus.BAD_REQUEST, "IMAGE400_1", "잘못된 이미지 ID 입니다 - image id 가 잘못된 형식인 경우"),
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST404_1", "존재하지 않는 게시글입니다 - 삭제된 게시글 또는 요청한 게시글을 찾을 수 없는 경우"),
-    POST_ALREADY_REACTED(HttpStatus.BAD_REQUEST, "POST403_2", "이미 좋아요/즐겨찾기 한 게시글입니다 - 중복된 요청인 경우");
+    POST_ALREADY_REACTED(HttpStatus.BAD_REQUEST, "POST403_2", "이미 좋아요/즐겨찾기 한 게시글입니다 - 중복된 요청인 경우"),
+
+    //Admin error
+    ADMIN_ALREADY_HANDLED_REPORT(HttpStatus.BAD_REQUEST, "ADMIN403_1", "이미 처리한 신고입니다 - 신고 처리를 이미 한 경우");
 
 
 


### PR DESCRIPTION
**_admin/report 안에 관련 Controller, Converter, ResponseDTO, Service 구현했습니다_**

**CommentEntity**
> - 댓글 바로 삭제 대신 상태만 DELETED로 바꾸기 위해 commentStatus, deletedAt 추가하고 setter 추가했습니다

**PostEntity**
> - status, deletedAt setter 추가했습니다

**ReportEntity**
> - 신고 처리 방법인 hadletype 추가하고 handletype과 status setter 추가했습니다

**BoardConverter, CommentConverter, PostConverter, ReportConverter**
> - board, comment, post, report entity 수정함에 따라 추가된 필드 관련 builder 수정했습니다

**ReportRepository**
> - 신고 조회를 위해 findByTypeOrderedByReportStatus, 신고 회수 조회를 위해 countAllByPost, countAllByComment 메서드 추가했습니다

**CommentStatus, ReportHandleType**
> - 댓글 삭제 여부, 신고 처리 방법에 해당하는 enum 추가했습니다

**ErrorStatus**
> - 신고 중복 처리에 해당하는 errorstatus 추가했습니다